### PR TITLE
use base-1 for OFE numbers

### DIFF
--- a/scripts/import/dbset_ofe.py
+++ b/scripts/import/dbset_ofe.py
@@ -42,7 +42,7 @@ def main(argv):
                     "f.huc_12 = %s and f.fpath = %s and p.length >= %s and "
                     "p.length < %s",
                     (
-                        i,
+                        i + 1,  # store OFE as 1-based
                         scenario,
                         huc12,
                         fpath,

--- a/scripts/util/dump_ofe_results.py
+++ b/scripts/util/dump_ofe_results.py
@@ -49,7 +49,7 @@ def main():
 
             for ofe in ofedf["ofe"].unique():
                 myofe = ofedf[ofedf["ofe"] == ofe]
-                meta_ofe = meta[meta["ofe"] == (ofe - 1)]
+                meta_ofe = meta[meta["ofe"] == ofe]
                 if meta_ofe.empty:
                     print(ofe, huc12, fpath)
                     sys.exit()


### PR DESCRIPTION
WEPP calls the first OFE "1", not "0", so lets not confuse people, like myself, by using "0"