### PR TITLE
⚡️ Better align queue fetch size to workers

### DIFF
--- a/scripts/RT/sweep_worker.py
+++ b/scripts/RT/sweep_worker.py
@@ -246,7 +246,7 @@ def ack_message(ch: Channel, delivery_tag):
     MEMORY["runs"] += 1
 
 
-def run_consumer(queue: str, jobfunc, executor):
+def run_consumer(queue: str, jobfunc, executor, prefetch_count: int):
     """Our main runloop."""
     LOG.info("Starting queue_worker for queue: %s", queue)
 
@@ -256,7 +256,7 @@ def run_consumer(queue: str, jobfunc, executor):
     # This is idempotent - safe to declare multiple times
     channel.queue_declare(queue, durable=True)
     # Limit unacknowledged messages to prevent overwhelming worker
-    channel.basic_qos(prefetch_count=300)
+    channel.basic_qos(prefetch_count=prefetch_count)
 
     def proxy(mychannel, method, _props, payload):
         """Wrapper around jobfunc."""
@@ -287,9 +287,21 @@ def print_timing():
 @click.option("--workers", type=int, required=True)
 @click.option("--drainme", is_flag=True)
 @click.option("--queue", default="depsweep", help="Queue name to consume from")
-def main(workers: int, drainme: bool, queue: str):
+@click.option(
+    "--prefetch-count",
+    type=int,
+    help="Maximum unacknowledged jobs to reserve per worker process",
+)
+def main(
+    workers: int,
+    drainme: bool,
+    queue: str,
+    prefetch_count: int | None,
+):
     """Go main Go."""
     jobfunc = run if not drainme else drain
+    if prefetch_count is None:
+        prefetch_count = workers
     # Start a thread to print timing every 300 seconds
     threading.Thread(target=print_timing, daemon=True).start()
     while True:
@@ -297,7 +309,7 @@ def main(workers: int, drainme: bool, queue: str):
         # connection.  Run until something bad happens, then start again!
         try:
             with ThreadPoolExecutor(max_workers=workers) as executor:
-                run_consumer(queue, jobfunc, executor)
+                run_consumer(queue, jobfunc, executor, prefetch_count)
             LOG.warning("run_consumer exited cleanly, sleeping 30 seconds")
             time.sleep(30)
         except KeyboardInterrupt:

--- a/scripts/RT/wepp_worker.py
+++ b/scripts/RT/wepp_worker.py
@@ -119,7 +119,7 @@ def ack_message(ch, delivery_tag):
     MEMORY["runs"] += 1
 
 
-def run_consumer(queue: str, jobfunc, executor):
+def run_consumer(queue: str, jobfunc, executor, prefetch_count: int):
     """Our main runloop."""
     LOG.info("Starting queue_worker for queue: %s", queue)
 
@@ -129,7 +129,7 @@ def run_consumer(queue: str, jobfunc, executor):
     # This is idempotent - safe to declare multiple times
     channel.queue_declare(queue, durable=True)
     # Limit unacknowledged messages to prevent overwhelming worker
-    channel.basic_qos(prefetch_count=300)
+    channel.basic_qos(prefetch_count=prefetch_count)
 
     def proxy(mychannel, method, _props, payload):
         """Wrapper around jobfunc."""
@@ -160,9 +160,21 @@ def print_timing():
 @click.option("--workers", type=int, required=True)
 @click.option("--drainme", is_flag=True)
 @click.option("--queue", default="dep", help="Queue name to consume from")
-def main(workers: int, drainme: bool, queue: str):
+@click.option(
+    "--prefetch-count",
+    type=int,
+    help="Maximum unacknowledged jobs to reserve per worker process",
+)
+def main(
+    workers: int,
+    drainme: bool,
+    queue: str,
+    prefetch_count: int | None,
+):
     """Go main Go."""
     jobfunc = run if not drainme else drain
+    if prefetch_count is None:
+        prefetch_count = workers
     # Start a thread to print timing every 300 seconds
     threading.Thread(target=print_timing, daemon=True).start()
     while True:
@@ -170,7 +182,7 @@ def main(workers: int, drainme: bool, queue: str):
         # connection.  Run until something bad happens, then start again!
         try:
             with ThreadPoolExecutor(max_workers=workers) as executor:
-                run_consumer(queue, jobfunc, executor)
+                run_consumer(queue, jobfunc, executor, prefetch_count)
             LOG.warning("run_consumer exited cleanly, sleeping 30 seconds")
             time.sleep(30)
         except KeyboardInterrupt:

--- a/scripts/RT/weps2sweep_worker.py
+++ b/scripts/RT/weps2sweep_worker.py
@@ -302,7 +302,7 @@ def ack_message(ch: Channel, delivery_tag):
     MEMORY["runs"] += 1
 
 
-def run_consumer(queue: str, jobfunc, executor):
+def run_consumer(queue: str, jobfunc, executor, prefetch_count: int):
     """Our main runloop."""
     LOG.info("Starting queue_worker for queue: %s", queue)
 
@@ -311,8 +311,7 @@ def run_consumer(queue: str, jobfunc, executor):
     # Declare queue as durable (must match producer)
     # This is idempotent - safe to declare multiple times
     channel.queue_declare(queue, durable=True)
-    # Limit unacknowledged messages to prevent overwhelming worker
-    channel.basic_qos(prefetch_count=300)
+    channel.basic_qos(prefetch_count=prefetch_count)
 
     def proxy(mychannel, method, _props, payload):
         """Wrapper around jobfunc."""
@@ -343,17 +342,30 @@ def print_timing():
 @click.option("--workers", type=int, required=True)
 @click.option("--drainme", is_flag=True)
 @click.option("--queue", default="depweps", help="Queue name to consume from")
-def main(workers: int, drainme: bool, queue: str):
+@click.option(
+    "--prefetch-count",
+    type=int,
+    help="Maximum unacknowledged jobs to reserve per worker process",
+)
+def main(
+    workers: int,
+    drainme: bool,
+    queue: str,
+    prefetch_count: int | None,
+):
     """Go main Go."""
     jobfunc = run if not drainme else drain
+    if prefetch_count is None:
+        prefetch_count = workers
     # Start a thread to print timing every 300 seconds
     threading.Thread(target=print_timing, daemon=True).start()
+
     while True:
         # Start a threadpool executor that is associated with a rabbitmq
         # connection.  Run until something bad happens, then start again!
         try:
             with ThreadPoolExecutor(max_workers=workers) as executor:
-                run_consumer(queue, jobfunc, executor)
+                run_consumer(queue, jobfunc, executor, prefetch_count)
             LOG.warning("run_consumer exited cleanly, sleeping 30 seconds")
             time.sleep(30)
         except KeyboardInterrupt:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable RabbitMQ prefetch count for worker processes. All worker commands now support a new `--prefetch-count` CLI option to control how many unacknowledged messages each worker reserves from the queue. When not specified, the prefetch count automatically defaults to the configured worker count, ensuring backward compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dailyerosion/dep/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->